### PR TITLE
fix #14

### DIFF
--- a/shapeloading/src/main/java/com/mingle/widget/LoadingView.java
+++ b/shapeloading/src/main/java/com/mingle/widget/LoadingView.java
@@ -191,62 +191,59 @@ public class LoadingView extends FrameLayout {
      */
     public void upThrow() {
 
-        ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(mShapeLoadingView, "translationY", mDistance, 0);
-        ObjectAnimator scaleIndication = ObjectAnimator.ofFloat(mIndicationIm, "scaleX", 0.2f, 1);
+        if (mUpAnimatorSet == null) {
+            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(mShapeLoadingView, "translationY", mDistance, 0);
+            ObjectAnimator scaleIndication = ObjectAnimator.ofFloat(mIndicationIm, "scaleX", 0.2f, 1);
 
+            ObjectAnimator objectAnimator1 = null;
+            switch (mShapeLoadingView.getShape()) {
+                case SHAPE_RECT:
 
-        ObjectAnimator objectAnimator1 = null;
-        switch (mShapeLoadingView.getShape()) {
-            case SHAPE_RECT:
+                    objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, -120);
 
+                    break;
+                case SHAPE_CIRCLE:
+                    objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, 180);
 
-                objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, -120);
+                    break;
+                case SHAPE_TRIANGLE:
 
-                break;
-            case SHAPE_CIRCLE:
-                objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, 180);
+                    objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, 180);
 
-                break;
-            case SHAPE_TRIANGLE:
+                    break;
+            }
 
-                objectAnimator1 = ObjectAnimator.ofFloat(mShapeLoadingView, "rotation", 0, 180);
+            objectAnimator.setDuration(ANIMATION_DURATION);
+            objectAnimator1.setDuration(ANIMATION_DURATION);
+            objectAnimator.setInterpolator(new DecelerateInterpolator(factor));
+            objectAnimator1.setInterpolator(new DecelerateInterpolator(factor));
+            mUpAnimatorSet = new AnimatorSet();
+            mUpAnimatorSet.setDuration(ANIMATION_DURATION);
+            mUpAnimatorSet.playTogether(objectAnimator, objectAnimator1, scaleIndication);
 
-                break;
+            mUpAnimatorSet.addListener(new Animator.AnimatorListener() {
+                @Override
+                public void onAnimationStart(Animator animation) {
+
+                }
+
+                @Override
+                public void onAnimationEnd(Animator animation) {
+                    freeFall();
+
+                }
+
+                @Override
+                public void onAnimationCancel(Animator animation) {
+
+                }
+
+                @Override
+                public void onAnimationRepeat(Animator animation) {
+
+                }
+            });
         }
-
-
-        objectAnimator.setDuration(ANIMATION_DURATION);
-        objectAnimator1.setDuration(ANIMATION_DURATION);
-        objectAnimator.setInterpolator(new DecelerateInterpolator(factor));
-        objectAnimator1.setInterpolator(new DecelerateInterpolator(factor));
-        mUpAnimatorSet = new AnimatorSet();
-        mUpAnimatorSet.setDuration(ANIMATION_DURATION);
-        mUpAnimatorSet.playTogether(objectAnimator, objectAnimator1, scaleIndication);
-
-
-        mUpAnimatorSet.addListener(new Animator.AnimatorListener() {
-            @Override
-            public void onAnimationStart(Animator animation) {
-
-            }
-
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                freeFall();
-
-
-            }
-
-            @Override
-            public void onAnimationCancel(Animator animation) {
-
-            }
-
-            @Override
-            public void onAnimationRepeat(Animator animation) {
-
-            }
-        });
         mUpAnimatorSet.start();
 
 
@@ -259,39 +256,39 @@ public class LoadingView extends FrameLayout {
      */
     public void freeFall() {
 
-        ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(mShapeLoadingView, "translationY", 0, mDistance);
-        ObjectAnimator scaleIndication = ObjectAnimator.ofFloat(mIndicationIm, "scaleX", 1, 0.2f);
+        if (mDownAnimatorSet == null) {
+            ObjectAnimator objectAnimator = ObjectAnimator.ofFloat(mShapeLoadingView, "translationY", 0, mDistance);
+            ObjectAnimator scaleIndication = ObjectAnimator.ofFloat(mIndicationIm, "scaleX", 1, 0.2f);
 
+            objectAnimator.setDuration(ANIMATION_DURATION);
+            objectAnimator.setInterpolator(new AccelerateInterpolator(factor));
+            mDownAnimatorSet = new AnimatorSet();
+            mDownAnimatorSet.setDuration(ANIMATION_DURATION);
+            mDownAnimatorSet.playTogether(objectAnimator, scaleIndication);
+            mDownAnimatorSet.addListener(new Animator.AnimatorListener() {
+                @Override
+                public void onAnimationStart(Animator animation) {
 
-        objectAnimator.setDuration(ANIMATION_DURATION);
-        objectAnimator.setInterpolator(new AccelerateInterpolator(factor));
-        mDownAnimatorSet = new AnimatorSet();
-        mDownAnimatorSet.setDuration(ANIMATION_DURATION);
-        mDownAnimatorSet.playTogether(objectAnimator, scaleIndication);
-        mDownAnimatorSet.addListener(new Animator.AnimatorListener() {
-            @Override
-            public void onAnimationStart(Animator animation) {
+                }
 
-            }
+                @Override
+                public void onAnimationEnd(Animator animation) {
 
-            @Override
-            public void onAnimationEnd(Animator animation) {
+                    mShapeLoadingView.changeShape();
+                    upThrow();
+                }
 
+                @Override
+                public void onAnimationCancel(Animator animation) {
 
-                mShapeLoadingView.changeShape();
-                upThrow();
-            }
+                }
 
-            @Override
-            public void onAnimationCancel(Animator animation) {
+                @Override
+                public void onAnimationRepeat(Animator animation) {
 
-            }
-
-            @Override
-            public void onAnimationRepeat(Animator animation) {
-
-            }
-        });
+                }
+            });
+        }
         mDownAnimatorSet.start();
 
 


### PR DESCRIPTION
fix #14 
修复上下移动的滑动因为每次都创建新的动画对象而导致的内存泄露。

mDownAnimatorSet 和 mUpAnimatorSet 由于每一次都创建新的对象，导致旧的对象没有对 Listener 进行释放，从而导致内存泄露。